### PR TITLE
SSV -> CSV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 .vscode/
 
 .cache/
+.DS_Store 
 
 # Gutenberg files from script
 archive/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,7 @@ void search_handler(ArrayList<std::string> args) {
 
   std::cout << "search_handler called with " << args.size() << " arguments." << std::endl;
   if (args.size() != 2) {
-    std::cerr << "Usage: search <index path>" << std::endl;
+    std::cerr << "Usage: search <index name>" << std::endl;
     return;
   }
 

--- a/tests/test_indexer.cpp
+++ b/tests/test_indexer.cpp
@@ -1,84 +1,83 @@
-#include <gtest/gtest.h>
-#include <fstream>
-#include <filesystem>
 #include "indexer.hpp"
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
 
 // NOTE: Helper function to create a temporary file
-void create_temp_file(const std::string& directory, const std::string& file_name, const std::string& content) {
-    std::ofstream file(directory + "/" + file_name);
-    file << content;
-    file.close();
+void create_temp_file(const std::string &directory,
+                      const std::string &file_name,
+                      const std::string &content) {
+  std::ofstream file(directory + "/" + file_name);
+  file << content;
+  file.close();
 }
 
-// TEST: GIVEN a valid directory and index file WHEN Indexer is constructed THEN it should correctly populate the list of files.
-TEST(IndexerTest, Constructor_InitializesFilesList) {
-    std::string temp_dir = "./test_data";
-    std::filesystem::create_directory(temp_dir);
-    create_temp_file(temp_dir, "file1.txt", "word1 word2 word3");
-    create_temp_file(temp_dir, "file2.txt", "word2 word3 word4");
+// TEST: GIVEN a directory with files WHEN create_temp_file is called THEN it
+// should create the files.
+TEST(IndexerTest, CreateTempFile) {
+  std::string temp_dir = "./test_data";
+  std::filesystem::create_directory(temp_dir);
+  create_temp_file(temp_dir, "file1.txt", "word1 word2 word3");
+  create_temp_file(temp_dir, "file2.txt", "word2 word3 word4");
 
-    Indexer indexer(temp_dir, "test_index.idx");
+  EXPECT_TRUE(std::filesystem::exists(temp_dir + "/file1.txt"));
+  EXPECT_TRUE(std::filesystem::exists(temp_dir + "/file2.txt"));
 
-    EXPECT_TRUE(std::filesystem::exists(temp_dir + "/file1.txt"));
-    EXPECT_TRUE(std::filesystem::exists(temp_dir + "/file2.txt"));
-
-    // Clean up
-    std::filesystem::remove_all(temp_dir);
+  std::filesystem::remove_all(temp_dir);
 }
 
-// TEST: GIVEN a file with words WHEN file_word_count is called THEN it should return the correct word frequency.
+// TEST: GIVEN a file with words WHEN file_word_count is called THEN it should
+// return the correct word frequency.
 TEST(IndexerTest, FileWordCount_CountsWords) {
-    std::string temp_dir = "./test_data";
-    std::filesystem::create_directory(temp_dir);
-    create_temp_file(temp_dir, "file1.txt", "word1 word2 word3 word1 word2");
+  std::string temp_dir = "./test_data";
+  std::filesystem::create_directory(temp_dir);
+  create_temp_file(temp_dir, "file1.txt", "word1 word2 word3 word1 word2");
 
-    Indexer indexer(temp_dir, "test_index.idx");
-    std::unordered_map<std::string, int> word_count = indexer.file_word_count("file1.txt");
+  Indexer indexer(temp_dir, "test_index.idx");
+  std::unordered_map<std::string, int> word_count =
+      indexer.file_word_count("file1.txt");
 
-    EXPECT_EQ(word_count["word1"], 2);
-    EXPECT_EQ(word_count["word2"], 2);
-    EXPECT_EQ(word_count["word3"], 1);
+  EXPECT_EQ(word_count["word1"], 2);
+  EXPECT_EQ(word_count["word2"], 2);
+  EXPECT_EQ(word_count["word3"], 1);
 
-    // Clean up
-    std::filesystem::remove_all(temp_dir);
+  // Clean up
+  std::filesystem::remove_all(temp_dir);
 }
 
-// TEST: GIVEN a directory with multiple files WHEN serialize_index is called THEN the index should be serialized correctly to a file.
+// TEST: GIVEN a directory with multiple files WHEN serialize_index is called
+// THEN the index should be serialized correctly to a file.
 TEST(IndexerTest, SerializeIndex_WritesToFile) {
-    std::string temp_dir = "./test_data";
-    std::filesystem::create_directory(temp_dir);
-    create_temp_file(temp_dir, "file1.txt", "word1 word2");
-    create_temp_file(temp_dir, "file2.txt", "word2 word3");
+  std::string temp_dir = "./test_data";
+  std::filesystem::create_directory(temp_dir);
+  create_temp_file(temp_dir, "file1.txt", "word1 word2");
+  create_temp_file(temp_dir, "file2.txt", "word2 word3");
 
-    Indexer indexer(temp_dir, "test_index.idx");
-    indexer.index_directory();
-    indexer.serialize_index();
+  Indexer indexer(temp_dir, "test_index.idx");
+  indexer.index_directory();
+  indexer.serialize_index();
 
-    // Check if the index file was created
-    EXPECT_TRUE(std::filesystem::exists("test_index.idx"));
+  // Check if the index file was created
+  EXPECT_TRUE(std::filesystem::exists("test_index.idx"));
 
-    // Read the file and check contents
-    std::ifstream index_file("test_index.idx");
-    std::string line;
-    std::getline(index_file, line); // Skip header
+  // Read the file and check contents
+  std::ifstream index_file("test_index.idx");
+  std::string line;
+  std::getline(index_file, line); // Skip header
 
-    std::unordered_map<std::string, int> expected_totals = {
-        {"word1", 1},
-        {"word2", 2},
-        {"word3", 1}
-    };
+  std::unordered_map<std::string, int> expected_totals = {
+      {"word1", 1}, {"word2", 2}, {"word3", 1}};
 
-    while (std::getline(index_file, line)) {
-        std::istringstream iss(line);
-        std::string word;
-        int total;
-        iss >> word >> total;
-        EXPECT_EQ(total, expected_totals[word]);
-    }
+  while (std::getline(index_file, line)) {
+    std::istringstream iss(line);
+    std::string word;
+    int total;
+    iss >> word >> total;
+    EXPECT_EQ(total, expected_totals[word]);
+  }
 
-    // Clean up
-    index_file.close();
-    std::filesystem::remove("test_index.idx");
-    std::filesystem::remove_all(temp_dir);
+  // Clean up
+  index_file.close();
+  std::filesystem::remove("test_index.idx");
+  std::filesystem::remove_all(temp_dir);
 }
-


### PR DESCRIPTION
To get something working I originally was serializing to a *space* separated values file (`SSV`), this ain't sustainable so now its `CSV` and words are cleaned to keep the `CSV` valid.

- So the `<index path>` arg for the `index` command is now `<index name>`.
- It also now saves in the same directory as the files archived as this makes more sense and will be easier to use if needed.

