### PR TITLE
Trie Integration for Predictive Search and Refactor Indexing Logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 .vscode/
 
 .cache/
+.DS_Store 
 
 # Gutenberg files from script
 archive/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ add_subdirectory(googletest)
 include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
 
 include_directories(include)
-add_executable(clouseau src/main.cpp src/cli.cpp src/indexer.cpp) 
+add_executable(clouseau src/main.cpp src/cli.cpp src/indexer.cpp src/trie.cpp) 
 
 enable_testing()
 include(GoogleTest)
@@ -29,7 +29,7 @@ target_link_libraries(test_array_list gtest gtest_main)
 gtest_discover_tests(test_array_list)
 
 # TEST: CLI implementation
-add_executable(test_cli tests/test_cli.cpp src/cli.cpp)
+add_executable(test_cli tests/test_cli.cpp src/cli.cpp src/trie.cpp src/indexer.cpp)
 target_link_libraries(test_cli gtest gtest_main)
 gtest_discover_tests(test_cli)
 
@@ -39,7 +39,7 @@ target_link_libraries(test_hash_map gtest gtest_main)
 gtest_discover_tests(test_hash_map)
 
 # TEST: Indexer implementation
-add_executable(test_indexer tests/test_indexer.cpp src/indexer.cpp)
+add_executable(test_indexer tests/test_indexer.cpp src/indexer.cpp src/trie.cpp)
 target_link_libraries(test_indexer gtest gtest_main)
 gtest_discover_tests(test_indexer)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ if(MSVC)
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
     add_compile_options(/std:c17)
+    add_definitions(-DPLATFORM_WINDOWS)  
+else()
+    add_definitions(-DPLATFORM_UNIX)  
 endif()
 
 # NOTE: Add Google Test submodule as a subdirectory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(CMAKE_CTEST_OUTPUT_ON_FAILURE TRUE)
 if(MSVC)
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
+    add_compile_options(/std:c17)
 endif()
 
 # NOTE: Add Google Test submodule as a subdirectory

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cd build
 
 # Build
 cmake ..
-make
+make #Windows: cmake --build .
 
 # Test
 make test

--- a/include/indexer.hpp
+++ b/include/indexer.hpp
@@ -1,5 +1,5 @@
 #pragma once
-
+#include "trie.hpp"
 #include "array_list.hpp"
 #include <mutex>
 #include <string>
@@ -19,6 +19,7 @@ struct Frequency {
 
 class Indexer {
 public:
+  Trie trie; 
   Indexer(const std::string &directory, const std::string &indexFile);
 
   // NOTE: Indexes all files in the directory and serializes the index

--- a/include/trie.hpp
+++ b/include/trie.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "array_list.hpp"
+#include <string>
+#include <unordered_map>
+
+class TrieNode {
+public:
+    char character;
+    bool is_end_of_word;
+    std::unordered_map<char, TrieNode*> children;
+    ArrayList<std::string> files;
+
+    TrieNode(char character) : character(character), is_end_of_word(false) {}
+};
+
+class Trie {
+public:
+    TrieNode* root;
+
+    Trie() : root(new TrieNode('\0')) {}
+
+    void insert(const std::string& word, const std::string& file);
+
+    ArrayList<std::string> search(const std::string& prefix);
+};

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include "cli.hpp"
+#include "indexer.hpp"
 
 CLI::CLI(std::string name, int argc, char *argv[]) {
   this->name = name;

--- a/src/indexer.cpp
+++ b/src/indexer.cpp
@@ -38,7 +38,7 @@ std::unordered_map<std::string, int> Indexer::file_word_count(const std::string 
     throw std::runtime_error("Could not open file");
   }
   std::string line;
-  int total_words = 0; // Add this line to count total words
+  int total_words = 0; 
   while (std::getline(input, line)) {
     std::string clean_word;
 
@@ -48,7 +48,7 @@ std::unordered_map<std::string, int> Indexer::file_word_count(const std::string 
       } else {
         if (!clean_word.empty()) {
           word_count[clean_word]++;
-          total_words++; // Increment total words
+          total_words++; 
           clean_word.clear();
         }
       }
@@ -58,10 +58,10 @@ std::unordered_map<std::string, int> Indexer::file_word_count(const std::string 
 
     if (!clean_word.empty()) {
       word_count[clean_word]++;
-      total_words++; // Increment total words
+      total_words++; 
     }
   }
-  word_count["__total_words__"] = total_words; // Store total words in the map
+  word_count["__total_words__"] = total_words; 
   return word_count;
 }
 
@@ -72,8 +72,8 @@ void Indexer::index_directory() {
   auto worker = [this](ArrayList<std::string> files) {
     for (const std::string &file : files) {
       std::unordered_map<std::string, int> word_count = file_word_count(file);
-      int total_words = word_count["__total_words__"]; // Retrieve total words
-      word_count.erase("__total_words__"); // Remove total words from the map
+      int total_words = word_count["__total_words__"]; 
+      word_count.erase("__total_words__"); 
 
       std::lock_guard<std::mutex> lock(index_mutex);
       for (auto const &pair : word_count) {
@@ -83,7 +83,7 @@ void Indexer::index_directory() {
           FileFrequency file_freq;
           file_freq.file = file;
           file_freq.count = pair.second;
-          file_freq.tf = pair.second / (double)total_words; // Correct term frequency calculation
+          file_freq.tf = pair.second / (double)total_words; 
           freq.files.push_back(file_freq);
           index[pair.first] = freq;
         } else {
@@ -91,7 +91,7 @@ void Indexer::index_directory() {
           FileFrequency file_freq;
           file_freq.file = file;
           file_freq.count = pair.second;
-          file_freq.tf = pair.second / (double)total_words; // Correct term frequency calculation
+          file_freq.tf = pair.second / (double)total_words; 
           index[pair.first].files.push_back(file_freq);
         }
         trie.insert(pair.first, file);

--- a/src/indexer.cpp
+++ b/src/indexer.cpp
@@ -9,6 +9,7 @@
 #include <thread>
 #include <unordered_map>
 #include <cmath>
+#include "trie.hpp"
 
 Indexer::Indexer(const std::string &directory, const std::string &indexFile) {
   this->directory = directory;
@@ -78,6 +79,8 @@ void Indexer::index_directory() {
           file_freq.count = pair.second;
           index[pair.first].files.push_back(file_freq);
         }
+        trie.insert(pair.first, file);
+      
       }
 
       for (auto &pair : index) {

--- a/src/indexer.cpp
+++ b/src/indexer.cpp
@@ -9,6 +9,7 @@
 #include <thread>
 #include <unordered_map>
 #include <cmath>
+#include <algorithm>
 #include "trie.hpp"
 
 Indexer::Indexer(const std::string &directory, const std::string &indexFile) {
@@ -20,46 +21,59 @@ Indexer::Indexer(const std::string &directory, const std::string &indexFile) {
       files.push_back(entry.path().filename().string());
     }
   }
+  
+  // Initialize the Trie
+  for (const std::string &file : files) {
+    std::unordered_map<std::string, int> word_count = file_word_count(file);
+    for (auto const &pair : word_count) {
+      trie.insert(pair.first, file);
+    }
+  }
 }
 
-std::unordered_map<std::string, int>
-Indexer::file_word_count(const std::string &file) {
+std::unordered_map<std::string, int> Indexer::file_word_count(const std::string &file) {
   std::unordered_map<std::string, int> word_count;
   std::ifstream input(directory + "/" + file);
   if (!input.is_open()) {
     throw std::runtime_error("Could not open file");
   }
   std::string line;
+  int total_words = 0; // Add this line to count total words
   while (std::getline(input, line)) {
     std::string clean_word;
 
     for (char &c : line) {
-      // NOTE: Keep letters, numbers, and allowed symbols (apostrophes and
-      // hyphens inside words)
       if (std::isalnum(c, std::locale()) || c == '\'' || c == '-') {
         clean_word += std::tolower(c, std::locale());
       } else {
-
         if (!clean_word.empty()) {
           word_count[clean_word]++;
+          total_words++; // Increment total words
           clean_word.clear();
         }
       }
     }
+
+    clean_word.erase(std::remove(clean_word.begin(), clean_word.end(), ','), clean_word.end());
+
     if (!clean_word.empty()) {
       word_count[clean_word]++;
+      total_words++; // Increment total words
     }
   }
+  word_count["__total_words__"] = total_words; // Store total words in the map
   return word_count;
 }
+
 
 void Indexer::index_directory() {
   ArrayList<std::thread> threads;
 
-  // NOTE: Anon func for each thread
   auto worker = [this](ArrayList<std::string> files) {
     for (const std::string &file : files) {
       std::unordered_map<std::string, int> word_count = file_word_count(file);
+      int total_words = word_count["__total_words__"]; // Retrieve total words
+      word_count.erase("__total_words__"); // Remove total words from the map
 
       std::lock_guard<std::mutex> lock(index_mutex);
       for (auto const &pair : word_count) {
@@ -69,7 +83,7 @@ void Indexer::index_directory() {
           FileFrequency file_freq;
           file_freq.file = file;
           file_freq.count = pair.second;
-          file_freq.tf = pair.second / (double)word_count.size(); // NOTE: Term frequency
+          file_freq.tf = pair.second / (double)total_words; // Correct term frequency calculation
           freq.files.push_back(file_freq);
           index[pair.first] = freq;
         } else {
@@ -77,10 +91,10 @@ void Indexer::index_directory() {
           FileFrequency file_freq;
           file_freq.file = file;
           file_freq.count = pair.second;
+          file_freq.tf = pair.second / (double)total_words; // Correct term frequency calculation
           index[pair.first].files.push_back(file_freq);
         }
         trie.insert(pair.first, file);
-      
       }
 
       for (auto &pair : index) {
@@ -91,16 +105,14 @@ void Indexer::index_directory() {
 
   int num_threads = std::thread::hardware_concurrency();
   if (num_threads == 0) {
-    num_threads = 1; // WARNING: hardware_concurrency returns 0 when the machine is single-core
+    num_threads = 1;
   }
-  std::cout << "Indexing " << files.size() << " files with " << num_threads
-            << " threads" << std::endl;
+  std::cout << "Indexing " << files.size() << " files with " << num_threads << " threads" << std::endl;
 
-  int files_per_thread = files.size() / num_threads; 
+  int files_per_thread = files.size() / num_threads;
   for (int i = 0; i < num_threads; i++) {
     ArrayList<std::string> thread_files;
-    for (int j = i * files_per_thread;
-         j < (i + 1) * files_per_thread && j < files.size(); j++) {
+    for (int j = i * files_per_thread; j < (i + 1) * files_per_thread && j < files.size(); j++) {
       thread_files.push_back(files[j]);
     }
     threads.push_back(std::thread(worker, thread_files));
@@ -111,15 +123,22 @@ void Indexer::index_directory() {
   }
 }
 
+
+
 void Indexer::serialize_index() {
-  std::ofstream index_file(indexFile);
-  index_file << "word idf total file1 tf1 count1 file2 tf2 count2 ..." << std::endl; // NOTE: Header
-  //
+  std::ofstream index_file(directory + "/" + indexFile);
+
+  // NOTE: Valid header
+  index_file << "word,idf,total,file1,tf1";
+  for (int i = 2; i <= files.size(); i++) {
+    index_file << ",file" << i << ",tf" << i;
+  }
+  index_file << std::endl;
+
   for (auto const &pair : index) {
-    index_file << pair.first << " " << pair.second.idf << " " << pair.second.total;
+    index_file << pair.first << "," << pair.second.idf << "," << pair.second.total;
     for (int i = 0; i < pair.second.files.size(); i++) {
-      index_file << " " << pair.second.files[i].file << " " << pair.second.files[i].tf
-                 << pair.second.files[i].count;
+      index_file << "," << pair.second.files[i].file << "," << pair.second.files[i].tf; 
     }
     index_file << std::endl;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,18 +2,37 @@
 #include "indexer.hpp"
 #include "array_list.hpp"
 #include <iostream>
+#include "trie.hpp"
+#include <libgen.h>
 
 void search_handler(ArrayList<std::string> args) {
+    std::cout << "search_handler called with " << args.size() << " arguments." << std::endl;
+    if (args.size() != 2) {
+        std::cerr << "Usage: search <index path>" << std::endl;
+        return;
+    }
 
-  std::cout << "search_handler called with " << args.size() << " arguments." << std::endl;
-  if (args.size() != 2) {
-    std::cerr << "Usage: search <index path>" << std::endl;
-    return;
-  }
+    std::string indexPath = args[1];
+    std::string dirPath = indexPath.substr(0, indexPath.find_last_of('/'));
 
-  std::cout << "Searching for " << args[1] << std::endl;
+    std::cout << "Searching for " << args[1] << std::endl;
 
-  return;
+    Indexer indexer(dirPath.c_str(), args[1].c_str()); 
+    Trie& trie = indexer.trie;
+
+    std::string prefix;
+    std::cout << "Enter a prefix to search: ";
+    std::cin >> prefix;
+
+    ArrayList<std::string> results = trie.search(prefix);
+    if (results.size() == 0) {
+        std::cout << "No results found." << std::endl;
+    } else {
+        std::cout << "Results:" << std::endl;
+        for (const std::string& file : results) {
+            std::cout << file << std::endl;
+        }
+    }
 }
 
 void index_handler(ArrayList<std::string> args) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,12 +25,37 @@ void search_handler(ArrayList<std::string> args) {
     std::cin >> prefix;
 
     ArrayList<std::string> results = trie.search(prefix);
+
     if (results.size() == 0) {
         std::cout << "No results found." << std::endl;
     } else {
-        std::cout << "Results:" << std::endl;
-        for (const std::string& file : results) {
-            std::cout << file << std::endl;
+        int result_count = results.size();
+        int display_count = 0;
+
+        while (result_count > 0) {
+            std::cout << "Search Results:" << std::endl;
+            for (int i = 0; i < 10 && i < result_count; i++) {
+                std::string file_path = dirPath + "/" + results[display_count];
+                std::string title = results[display_count]; // assuming title is the same as file name
+
+                std::cout << "Title: " << title << std::endl;
+                std::cout << "File Path: " << file_path << std::endl;
+                std::cout << std::endl;
+
+                display_count++;
+            }
+
+            result_count -= 10;
+
+            if (result_count > 0) {
+                std::cout << "Press 'q' to quit or any other key to display the next 10 results: ";
+                char response;
+                std::cin >> response;
+
+                if (response == 'q') {
+                    break;
+                }
+            }
         }
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,39 +20,50 @@ void search_handler(ArrayList<std::string> args) {
     Indexer indexer(dirPath.c_str(), args[1].c_str()); 
     Trie& trie = indexer.trie;
 
-    std::string prefix;
-    std::cout << "Enter a prefix to search: ";
-    std::cin >> prefix;
+    while (true) {
+        std::string prefix;
+        std::cout << "Enter a prefix to search: ";
+        std::cin >> prefix;
 
-    ArrayList<std::string> results = trie.search(prefix);
+        ArrayList<std::string> results = trie.search(prefix);
 
-    if (results.size() == 0) {
-        std::cout << "No results found." << std::endl;
-    } else {
-        int result_count = results.size();
-        int display_count = 0;
+        if (results.size() == 0) {
+            std::cout << "No results found." << std::endl;
+        } else {
+            int result_count = results.size();
+            int display_count = 0;
 
-        while (result_count > 0) {
-            std::cout << "\nSearch Results:" << std::endl;
-            for (int i = 0; i < 10 && i < result_count; i++) {
-                std::string file_path = dirPath + "/" + results[display_count];
-                std::string title = results[display_count];
+            while (result_count > 0) {
+                std::cout << "\nSearch Results:" << std::endl;
+                for (int i = 0; i < 10 && i < result_count; i++) {
+                    std::string file_path = dirPath + "/" + results[display_count];
+                    std::string title = results[display_count];
 
-                std::cout << "Title: " << title << std::endl;
-                std::cout << "File Path: " << file_path << std::endl;
-                std::cout << std::endl;
+                    std::cout << "Title: " << title << std::endl;
+                    std::cout << "File Path: " << file_path << std::endl;
+                    std::cout << std::endl;
 
-                display_count++;
-            }
+                    display_count++;
+                }
 
-            result_count -= 10;
+                result_count -= 10;
 
-            if (result_count > 0) {
-                std::cout << "Press 'q' to quit or any other key to display the next 10 results: ";
-                char response;
-                std::cin >> response;
+                if (result_count > 0) {
+                    std::cout << "Press [Enter] to display the next 10 results, or type 'quit' to exit: ";
+                    std::string response;
+                    std::cin.ignore(); 
+                    std::getline(std::cin, response);
 
-                if (response == 'q') {
+                    if (response == "quit") {
+                        return; 
+                    } else if (response.empty()) {
+                        continue;
+                    } else {
+                        std::cout << "Invalid input. Please press [Enter] or type 'quit'." << std::endl;
+                        continue;
+                    }
+                } else {
+                    std::cout << "No more entries found. Please search for a new word." << std::endl;
                     break;
                 }
             }
@@ -61,21 +72,21 @@ void search_handler(ArrayList<std::string> args) {
 }
 
 void index_handler(ArrayList<std::string> args) {
-  if (args.size() != 3) {
-    std::cerr << "Usage: index <input directory> <index path>" << std::endl;
-    return;
-  }
+    if (args.size() != 3) {
+        std::cerr << "Usage: index <input directory> <index path>" << std::endl;
+        return;
+    }
 
-  Indexer indexer(args[1], args[2]);
-  indexer.index_directory();
-  indexer.serialize_index();
+    Indexer indexer(args[1], args[2]);
+    indexer.index_directory();
+    indexer.serialize_index();
 }
 
 int main(int argc, char *argv[]) {
-  CLI cli("clouseau", argc, argv);
-  cli.add_cmd("search", Cmd{"Search for a file", search_handler});
-  cli.add_cmd("index", Cmd{"Index a directory", index_handler});
-  cli.run();
+    CLI cli("clouseau", argc, argv);
+    cli.add_cmd("search", Cmd{"Search for a file", search_handler});
+    cli.add_cmd("index", Cmd{"Index a directory", index_handler});
+    cli.run();
 
-  return 0;
+    return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@
 void search_handler(ArrayList<std::string> args) {
     std::cout << "search_handler called with " << args.size() << " arguments." << std::endl;
     if (args.size() != 2) {
-        std::cerr << "Usage: search <index path>" << std::endl;
+        std::cerr << "Usage: search <index name>" << std::endl;
         return;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@ void search_handler(ArrayList<std::string> args) {
     std::string indexPath = args[1];
     std::string dirPath = indexPath.substr(0, indexPath.find_last_of('/'));
 
-    std::cout << "Searching for " << args[1] << std::endl;
+    std::cout << "Searching: " << args[1] << std::endl;
 
     Indexer indexer(dirPath.c_str(), args[1].c_str()); 
     Trie& trie = indexer.trie;
@@ -33,10 +33,10 @@ void search_handler(ArrayList<std::string> args) {
         int display_count = 0;
 
         while (result_count > 0) {
-            std::cout << "Search Results:" << std::endl;
+            std::cout << "\nSearch Results:" << std::endl;
             for (int i = 0; i < 10 && i < result_count; i++) {
                 std::string file_path = dirPath + "/" + results[display_count];
-                std::string title = results[display_count]; // assuming title is the same as file name
+                std::string title = results[display_count];
 
                 std::cout << "Title: " << title << std::endl;
                 std::cout << "File Path: " << file_path << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,11 @@
 #include "array_list.hpp"
 #include <iostream>
 #include "trie.hpp"
+#ifdef _WIN32
+#include <direct.h>
+#else 
 #include <libgen.h>
+#endif
 
 void search_handler(ArrayList<std::string> args) {
     std::cout << "search_handler called with " << args.size() << " arguments." << std::endl;

--- a/src/trie.cpp
+++ b/src/trie.cpp
@@ -1,0 +1,26 @@
+#include "trie.hpp"
+#include "indexer.hpp"
+#include <iostream>
+
+void Trie::insert(const std::string& word, const std::string& file) {
+    TrieNode* current = root;
+    for (char c : word) {
+        if (current->children.find(c) == current->children.end()) {
+            current->children[c] = new TrieNode(c);
+        }
+        current = current->children[c];
+    }
+    current->is_end_of_word = true;
+    current->files.push_back(file);
+}
+
+ArrayList<std::string> Trie::search(const std::string& prefix) {
+    TrieNode* current = root;
+    for (char c : prefix) {
+        if (current->children.find(c) == current->children.end()) {
+            return ArrayList<std::string>();
+        }
+        current = current->children[c];
+    }
+    return current->files;
+}

--- a/tests/test_indexer.cpp
+++ b/tests/test_indexer.cpp
@@ -66,7 +66,10 @@ TEST(IndexerTest, SerializeIndex_WritesToFile) {
   std::getline(index_file, line); // Skip header
 
   std::unordered_map<std::string, int> expected_totals = {
-      {"word1", 1}, {"word2", 2}, {"word3", 1}};
+    {"word1", 1},
+    {"word2", 2},
+    {"word3", 1}
+  };
 
   while (std::getline(index_file, line)) {
     std::istringstream iss(line);

--- a/tests/test_indexer.cpp
+++ b/tests/test_indexer.cpp
@@ -53,7 +53,7 @@ TEST(IndexerTest, SerializeIndex_WritesToFile) {
   create_temp_file(temp_dir, "file1.txt", "word1 word2");
   create_temp_file(temp_dir, "file2.txt", "word2 word3");
 
-  Indexer indexer(temp_dir, "test_index");
+  Indexer indexer(temp_dir, "test_index.csv");
   indexer.index_directory();
   indexer.serialize_index();
 

--- a/tests/test_indexer.cpp
+++ b/tests/test_indexer.cpp
@@ -1,84 +1,83 @@
-#include <gtest/gtest.h>
-#include <fstream>
-#include <filesystem>
 #include "indexer.hpp"
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
 
 // NOTE: Helper function to create a temporary file
-void create_temp_file(const std::string& directory, const std::string& file_name, const std::string& content) {
-    std::ofstream file(directory + "/" + file_name);
-    file << content;
-    file.close();
+void create_temp_file(const std::string &directory,
+                      const std::string &file_name,
+                      const std::string &content) {
+  std::ofstream file(directory + "/" + file_name);
+  file << content;
+  file.close();
 }
 
-// TEST: GIVEN a valid directory and index file WHEN Indexer is constructed THEN it should correctly populate the list of files.
-TEST(IndexerTest, Constructor_InitializesFilesList) {
-    std::string temp_dir = "./test_data";
-    std::filesystem::create_directory(temp_dir);
-    create_temp_file(temp_dir, "file1.txt", "word1 word2 word3");
-    create_temp_file(temp_dir, "file2.txt", "word2 word3 word4");
+// TEST: GIVEN a directory with files WHEN create_temp_file is called THEN it
+// should create the files.
+TEST(IndexerTest, CreateTempFile) {
+  std::string temp_dir = "./test_data";
+  std::filesystem::create_directory(temp_dir);
+  create_temp_file(temp_dir, "file1.txt", "word1 word2 word3");
+  create_temp_file(temp_dir, "file2.txt", "word2 word3 word4");
 
-    Indexer indexer(temp_dir, "test_index.idx");
+  EXPECT_TRUE(std::filesystem::exists(temp_dir + "/file1.txt"));
+  EXPECT_TRUE(std::filesystem::exists(temp_dir + "/file2.txt"));
 
-    EXPECT_TRUE(std::filesystem::exists(temp_dir + "/file1.txt"));
-    EXPECT_TRUE(std::filesystem::exists(temp_dir + "/file2.txt"));
-
-    // Clean up
-    std::filesystem::remove_all(temp_dir);
+  std::filesystem::remove_all(temp_dir);
 }
 
-// TEST: GIVEN a file with words WHEN file_word_count is called THEN it should return the correct word frequency.
+// TEST: GIVEN a file with words WHEN file_word_count is called THEN it should
+// return the correct word frequency.
 TEST(IndexerTest, FileWordCount_CountsWords) {
-    std::string temp_dir = "./test_data";
-    std::filesystem::create_directory(temp_dir);
-    create_temp_file(temp_dir, "file1.txt", "word1 word2 word3 word1 word2");
+  std::string temp_dir = "./test_data";
+  std::filesystem::create_directory(temp_dir);
+  create_temp_file(temp_dir, "file1.txt", "word1 word2 word3 word1 word2");
 
-    Indexer indexer(temp_dir, "test_index.idx");
-    std::unordered_map<std::string, int> word_count = indexer.file_word_count("file1.txt");
+  Indexer indexer(temp_dir, "test_index.idx");
+  std::unordered_map<std::string, int> word_count =
+      indexer.file_word_count("file1.txt");
 
-    EXPECT_EQ(word_count["word1"], 2);
-    EXPECT_EQ(word_count["word2"], 2);
-    EXPECT_EQ(word_count["word3"], 1);
+  EXPECT_EQ(word_count["word1"], 2);
+  EXPECT_EQ(word_count["word2"], 2);
+  EXPECT_EQ(word_count["word3"], 1);
 
-    // Clean up
-    std::filesystem::remove_all(temp_dir);
+  // Clean up
+  std::filesystem::remove_all(temp_dir);
 }
 
-// TEST: GIVEN a directory with multiple files WHEN serialize_index is called THEN the index should be serialized correctly to a file.
+// TEST: GIVEN a directory with multiple files WHEN serialize_index is called
+// THEN the index should be serialized correctly to a file.
 TEST(IndexerTest, SerializeIndex_WritesToFile) {
-    std::string temp_dir = "./test_data";
-    std::filesystem::create_directory(temp_dir);
-    create_temp_file(temp_dir, "file1.txt", "word1 word2");
-    create_temp_file(temp_dir, "file2.txt", "word2 word3");
+  std::string temp_dir = "./test_data";
+  std::filesystem::create_directory(temp_dir);
+  create_temp_file(temp_dir, "file1.txt", "word1 word2");
+  create_temp_file(temp_dir, "file2.txt", "word2 word3");
 
-    Indexer indexer(temp_dir, "test_index.idx");
-    indexer.index_directory();
-    indexer.serialize_index();
+  Indexer indexer(temp_dir, "test_index");
+  indexer.index_directory();
+  indexer.serialize_index();
 
-    // Check if the index file was created
-    EXPECT_TRUE(std::filesystem::exists("test_index.idx"));
+  // Check if the index file was created
+  EXPECT_TRUE(std::filesystem::exists(temp_dir + "/test_index.csv"));
 
-    // Read the file and check contents
-    std::ifstream index_file("test_index.idx");
-    std::string line;
-    std::getline(index_file, line); // Skip header
+  // Read the file and check contents
+  std::ifstream index_file("test_index.idx");
+  std::string line;
+  std::getline(index_file, line); // Skip header
 
-    std::unordered_map<std::string, int> expected_totals = {
-        {"word1", 1},
-        {"word2", 2},
-        {"word3", 1}
-    };
+  std::unordered_map<std::string, int> expected_totals = {
+      {"word1", 1}, {"word2", 2}, {"word3", 1}};
 
-    while (std::getline(index_file, line)) {
-        std::istringstream iss(line);
-        std::string word;
-        int total;
-        iss >> word >> total;
-        EXPECT_EQ(total, expected_totals[word]);
-    }
+  while (std::getline(index_file, line)) {
+    std::istringstream iss(line);
+    std::string word;
+    int total;
+    iss >> word >> total;
+    EXPECT_EQ(total, expected_totals[word]);
+  }
 
-    // Clean up
-    index_file.close();
-    std::filesystem::remove("test_index.idx");
-    std::filesystem::remove_all(temp_dir);
+  // Clean up
+  index_file.close();
+  std::filesystem::remove("test_index.idx");
+  std::filesystem::remove_all(temp_dir);
 }
-


### PR DESCRIPTION
Integration of the Trie for predictive search and optimizations in the indexing logic. The following changes have been made:

**CMakeLists.txt:**
-  Compile options for /std:c17 to improve standard compatibility on MSVC.
-  The clouseau executable now includes trie.cpp for Trie integration.
- Tests now link trie.cpp to ensure coverage of Trie-related functionality.

**indexer.hpp and indexer.cpp:**
- Integration of Trie into the indexer for inserting and searching words.
- Adjusted the word count logic, including tracking total word counts (__total_words__) for more accurate TF calculations.
-  File word count logic to use the cleaned word for indexing and calculating term frequency (TF).

**trie.hpp and trie.cpp:**
-  Implemented the Trie class and its methods, insert and search, to enable predictive search capabilities for the indexed files.

**cli.cpp:**
-  Trie's search capability to the CLI for handling user input and displaying search results.

**main.cpp:**

1. Updated the argument handling in _search_handler_:
- Extracted indexPath and directory path (dirPath) from the argument for proper Trie initialization.

2. Replaced old Indexer initialization to reflect new Trie usage:
- Now creates a reference to Trie from Indexer.
- Implemented interactive prefix-based search using Trie for autocomplete-like functionality.

3. Enhanced search result display:
- Display results in batches of 10, with pagination support via [Enter] or 'quit' command.

Current output: 

<img width="860" alt="output github" src="https://github.com/user-attachments/assets/b4cc865d-9f8b-4a6c-bb5f-9d7430b0f904">
